### PR TITLE
Add lightweight integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
             . venv/bin/activate
             cd integration_tests
             dbt deps --target postgres
+            dbt run-operation create_source_table --target postgres
             dbt seed --target postgres --full-refresh
             dbt run --target postgres
             dbt test --target postgres
@@ -52,6 +53,7 @@ jobs:
             echo `pwd`
             cd integration_tests
             dbt deps --target redshift
+            dbt run-operation create_source_table --target redshift
             dbt seed --target redshift --full-refresh
             dbt run --target redshift
             dbt test --target redshift
@@ -63,6 +65,7 @@ jobs:
             echo `pwd`
             cd integration_tests
             dbt deps --target snowflake
+            dbt run-operation create_source_table --target snowflake
             dbt seed --target snowflake --full-refresh
             dbt run --target snowflake
             dbt test --target snowflake
@@ -77,6 +80,7 @@ jobs:
             echo `pwd`
             cd integration_tests
             dbt deps --target bigquery
+            dbt run-operation create_source_table --target bigquery
             dbt seed --target bigquery --full-refresh
             dbt run --target bigquery
             dbt test --target bigquery

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             . venv/bin/activate
 
             pip install --upgrade pip setuptools
-            pip install dbt
+            pip install dbt --pre # using pre-release for unreleased 0.14.0 functionality
 
             mkdir -p ~/.dbt
             cp integration_tests/ci/sample.profiles.yml ~/.dbt/profiles.yml
@@ -42,6 +42,7 @@ jobs:
             cd integration_tests
             dbt deps --target postgres
             dbt run-operation create_source_table --target postgres
+            dbt compile --target postgres
             dbt seed --target postgres --full-refresh
             dbt run --target postgres
             dbt test --target postgres
@@ -54,6 +55,7 @@ jobs:
             cd integration_tests
             dbt deps --target redshift
             dbt run-operation create_source_table --target redshift
+            dbt compile --target redshift
             dbt seed --target redshift --full-refresh
             dbt run --target redshift
             dbt test --target redshift
@@ -66,6 +68,7 @@ jobs:
             cd integration_tests
             dbt deps --target snowflake
             dbt run-operation create_source_table --target snowflake
+            dbt compile --target snowflake
             dbt seed --target snowflake --full-refresh
             dbt run --target snowflake
             dbt test --target snowflake
@@ -81,6 +84,7 @@ jobs:
             cd integration_tests
             dbt deps --target bigquery
             dbt run-operation create_source_table --target bigquery
+            dbt compile --target bigquery
             dbt seed --target bigquery --full-refresh
             dbt run --target bigquery
             dbt test --target bigquery

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,88 @@
+
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.6.2-stretch
+      - image: circleci/postgres:9.6.5-alpine-ram
+
+    steps:
+      - checkout
+
+      - run:
+          run: setup_creds
+          command: |
+            echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > ${HOME}/gcloud-service-key.json
+
+      - restore_cache:
+          key: deps1-{{ .Branch }}
+
+      - run:
+          name: "Setup dbt"
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+
+            pip install --upgrade pip setuptools
+            pip install dbt
+
+            mkdir -p ~/.dbt
+            cp integration_tests/ci/sample.profiles.yml ~/.dbt/profiles.yml
+
+      - run:
+          name: "Run Tests - Postgres"
+          environment:
+            CI_DBT_USER: root
+            CI_DBT_PASS: ''
+            CI_DBT_PORT: 5432
+            CI_DBT_DBNAME: circle_test
+          command: |
+            . venv/bin/activate
+            cd integration_tests
+            dbt deps --target postgres
+            dbt seed --target postgres --full-refresh
+            dbt run --target postgres
+            dbt test --target postgres
+
+      - run:
+          name: "Run Tests - Redshift"
+          command: |
+            . venv/bin/activate
+            echo `pwd`
+            cd integration_tests
+            dbt deps --target redshift
+            dbt seed --target redshift --full-refresh
+            dbt run --target redshift
+            dbt test --target redshift
+
+      - run:
+          name: "Run Tests - Snowflake"
+          command: |
+            . venv/bin/activate
+            echo `pwd`
+            cd integration_tests
+            dbt deps --target snowflake
+            dbt seed --target snowflake --full-refresh
+            dbt run --target snowflake
+            dbt test --target snowflake
+
+      - run:
+          name: "Run Tests - BigQuery"
+          environment:
+              GCLOUD_SERVICE_KEY_PATH: "/home/circleci/gcloud-service-key.json"
+
+          command: |
+            . venv/bin/activate
+            echo `pwd`
+            cd integration_tests
+            dbt deps --target bigquery
+            dbt seed --target bigquery --full-refresh
+            dbt run --target bigquery
+            dbt test --target bigquery
+
+
+      - save_cache:
+          key: deps1-{{ .Branch }}
+          paths:
+            - "venv"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             . venv/bin/activate
 
             pip install --upgrade pip setuptools
-            pip install dbt --pre # using pre-release for unreleased 0.14.0 functionality
+            pip install dbt --upgrade --pre # using pre-release for unreleased 0.14.0 functionality
 
             mkdir -p ~/.dbt
             cp integration_tests/ci/sample.profiles.yml ~/.dbt/profiles.yml

--- a/integration_tests/analysis/test_generate_base_model.sql
+++ b/integration_tests/analysis/test_generate_base_model.sql
@@ -1,0 +1,8 @@
+{% set raw_schema=generate_schema_name('raw_data') %}
+
+{{
+  codegen.generate_base_model(
+    source_name=raw_schema,
+    table_name='data__a_relation'
+  )
+}}

--- a/integration_tests/analysis/test_generate_base_model.sql
+++ b/integration_tests/analysis/test_generate_base_model.sql
@@ -1,8 +1,6 @@
-{% set raw_schema=generate_schema_name('raw_data') %}
-
 {{
   codegen.generate_base_model(
-    source_name=raw_schema,
-    table_name='data__a_relation'
+    source_name='test_data_source',
+    table_name='my_test_table'
   )
 }}

--- a/integration_tests/analysis/test_generate_base_model.sql
+++ b/integration_tests/analysis/test_generate_base_model.sql
@@ -1,6 +1,6 @@
 {{
   codegen.generate_base_model(
-    source_name='test_data_source',
-    table_name='my_test_table'
+    source_name='codegen_integration_tests__data_source_schema',
+    table_name='codegen_integration_tests__data_source_table'
   )
 }}

--- a/integration_tests/analysis/test_generate_source.sql
+++ b/integration_tests/analysis/test_generate_source.sql
@@ -1,0 +1,11 @@
+{% set raw_schema=generate_schema_name('raw_data') %}
+
+-- test default args
+{{ codegen.generate_source(raw_schema) }}
+
+-- test all args
+{{ codegen.generate_source(
+    schema_name=raw_schema,
+    database_name=target.database,
+    generate_columns=True
+) }}

--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -16,7 +16,7 @@ codegen_integration_tests:
       pass: "{{ env_var('CI_DBT_PASS') }}"
       port: "{{ env_var('CI_DBT_PORT') }}"
       dbname: "{{ env_var('CI_DBT_DBNAME') }}"
-      schema: codegen_integration_tests_postgres
+      schema: codegen_integration_tests
       threads: 1
 
     redshift:
@@ -26,7 +26,7 @@ codegen_integration_tests:
       pass: "{{ env_var('CI_REDSHIFT_DBT_PASS') }}"
       dbname: "{{ env_var('CI_REDSHIFT_DBT_DBNAME') }}"
       port: 5439
-      schema: codegen_integration_tests_redshift
+      schema: codegen_integration_tests
       threads: 1
 
     bigquery:
@@ -34,7 +34,7 @@ codegen_integration_tests:
       method: service-account
       keyfile: "{{ env_var('GCLOUD_SERVICE_KEY_PATH') }}"
       project: 'dbt-integration-tests'
-      schema: codegen_integration_tests_bigquery
+      schema: codegen_integration_tests
       threads: 1
 
     snowflake:
@@ -45,5 +45,5 @@ codegen_integration_tests:
       role: "{{ env_var('CI_SNOWFLAKE_DBT_ROLE') }}"
       database: "{{ env_var('CI_SNOWFLAKE_DBT_DATABASE') }}"
       warehouse: "{{ env_var('CI_SNOWFLAKE_DBT_WAREHOUSE') }}"
-      schema: codegen_integration_tests_snowflake
+      schema: codegen_integration_tests
       threads: 1

--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -1,0 +1,49 @@
+
+# HEY! This file is used in the dbt-utils integrations tests with CircleCI.
+# You should __NEVER__ check credentials into version control. Thanks for reading :)
+
+config:
+    send_anonymous_usage_stats: False
+    use_colors: True
+
+codegen_integration_tests:
+  target: postgres
+  outputs:
+    postgres:
+      type: postgres
+      host: localhost
+      user: "{{ env_var('CI_DBT_USER') }}"
+      pass: "{{ env_var('CI_DBT_PASS') }}"
+      port: "{{ env_var('CI_DBT_PORT') }}"
+      dbname: "{{ env_var('CI_DBT_DBNAME') }}"
+      schema: codegen_integration_tests_postgres
+      threads: 1
+
+    redshift:
+      type: redshift
+      host: "{{ env_var('CI_REDSHIFT_DBT_HOST') }}"
+      user: "{{ env_var('CI_REDSHIFT_DBT_USER') }}"
+      pass: "{{ env_var('CI_REDSHIFT_DBT_PASS') }}"
+      dbname: "{{ env_var('CI_REDSHIFT_DBT_DBNAME') }}"
+      port: 5439
+      schema: codegen_integration_tests_redshift
+      threads: 1
+
+    bigquery:
+      type: bigquery
+      method: service-account
+      keyfile: "{{ env_var('GCLOUD_SERVICE_KEY_PATH') }}"
+      project: 'dbt-integration-tests'
+      schema: codegen_integration_tests_bigquery
+      threads: 1
+
+    snowflake:
+      type: snowflake
+      account: "{{ env_var('CI_SNOWFLAKE_DBT_ACCOUNT') }}"
+      user: "{{ env_var('CI_SNOWFLAKE_DBT_USER') }}"
+      password: "{{ env_var('CI_SNOWFLAKE_DBT_PASS') }}"
+      role: "{{ env_var('CI_SNOWFLAKE_DBT_ROLE') }}"
+      database: "{{ env_var('CI_SNOWFLAKE_DBT_DATABASE') }}"
+      warehouse: "{{ env_var('CI_SNOWFLAKE_DBT_WAREHOUSE') }}"
+      schema: codegen_integration_tests_snowflake
+      threads: 1

--- a/integration_tests/data/data__a_relation.csv
+++ b/integration_tests/data/data__a_relation.csv
@@ -1,0 +1,3 @@
+col_a,col_b
+1,a
+2,b

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,0 +1,19 @@
+
+name: 'codegen_integration_tests'
+version: '1.0'
+
+profile: 'codegen_integration_tests'
+
+source-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+data-paths: ["data"]
+macro-paths: ["macros"]
+
+target-path: "target"
+clean-targets:
+    - "target"
+    - "dbt_modules"
+
+seeds:
+  schema: raw_data

--- a/integration_tests/macros/create_source_table.sql
+++ b/integration_tests/macros/create_source_table.sql
@@ -4,16 +4,21 @@
 
 {% do adapter.create_schema(target.database, target_schema) %}
 
-{% set query_sql %}
-drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_table;
+{% set drop_table_sql %}
+drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_table
+{% endset %}
+
+{{ run_query(drop_table_sql) }}
+
+
+{% set create_table_sql %}
 create table {{ target_schema }}.codegen_integration_tests__data_source_table as (
     select
         1 as my_integer_col,
         true as my_bool_col
 )
-
 {% endset %}
 
-{{ run_query(query_sql) }}
+{{ run_query(create_table_sql) }}
 
 {% endmacro %}

--- a/integration_tests/macros/create_source_table.sql
+++ b/integration_tests/macros/create_source_table.sql
@@ -1,0 +1,26 @@
+{% macro create_source_table() %}
+
+{% set target_schema="test_data_source" %}
+
+{% do adapter.create_schema(target.database, target_schema) %}
+
+{%- set target_relation = api.Relation.create(
+    identifier='my_test_table',
+    schema=target_schema,
+    type='table'
+) %}
+
+
+{% set source_sql %}
+select
+    1 as my_integer_col,
+    true as my_bool_col
+{% endset %}
+
+{% do create_table_as(
+    temporary=False,
+    relation=target_relation,
+    sql=source_sql
+) %}
+
+{% endmacro %}

--- a/integration_tests/macros/create_source_table.sql
+++ b/integration_tests/macros/create_source_table.sql
@@ -1,26 +1,19 @@
 {% macro create_source_table() %}
 
-{% set target_schema="test_data_source" %}
+{% set target_schema="codegen_integration_tests__data_source_schema" %}
 
 {% do adapter.create_schema(target.database, target_schema) %}
 
-{%- set target_relation = api.Relation.create(
-    identifier='my_test_table',
-    schema=target_schema,
-    type='table'
-) %}
+{% set query_sql %}
+drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_table;
+create table {{ target_schema }}.codegen_integration_tests__data_source_table as (
+    select
+        1 as my_integer_col,
+        true as my_bool_col
+)
 
-
-{% set source_sql %}
-select
-    1 as my_integer_col,
-    true as my_bool_col
 {% endset %}
 
-{% do create_table_as(
-    temporary=False,
-    relation=target_relation,
-    sql=source_sql
-) %}
+{{ run_query(query_sql) }}
 
 {% endmacro %}

--- a/integration_tests/models/source.yml
+++ b/integration_tests/models/source.yml
@@ -1,0 +1,7 @@
+version: 2
+
+sources:
+  - name: raw_data
+    schema: "{{ generate_schema_name('raw_data') }}"
+    tables:
+      - name: data__a_relation

--- a/integration_tests/models/source.yml
+++ b/integration_tests/models/source.yml
@@ -2,6 +2,7 @@ version: 2
 
 sources:
   - name: raw_data
-    schema: "{{ generate_schema_name('raw_data') }}"
+    # have to hardcode this as I can't access the generate_schema_name macro
+    identifer: codegen_integration_tests_raw_data
     tables:
       - name: data__a_relation

--- a/integration_tests/models/source.yml
+++ b/integration_tests/models/source.yml
@@ -3,6 +3,6 @@ version: 2
 sources:
   - name: raw_data
     # have to hardcode this as I can't access the generate_schema_name macro
-    identifer: codegen_integration_tests_raw_data
+    schema: codegen_integration_tests_raw_data
     tables:
       - name: data__a_relation

--- a/integration_tests/models/source.yml
+++ b/integration_tests/models/source.yml
@@ -1,8 +1,6 @@
 version: 2
 
 sources:
-  - name: raw_data
-    # have to hardcode this as I can't access the generate_schema_name macro
-    schema: codegen_integration_tests_raw_data
+  - name: codegen_integration_tests__data_source_schema
     tables:
-      - name: data__a_relation
+      - name: codegen_integration_tests__data_source_table

--- a/integration_tests/packages.yml
+++ b/integration_tests/packages.yml
@@ -1,0 +1,3 @@
+
+packages:
+    - local: ../

--- a/macros/generate_base_model.sql
+++ b/macros/generate_base_model.sql
@@ -7,7 +7,7 @@
 {% set base_model_sql %}
 with source as (
 
-    select * from {% raw %}{{ source({% endraw %}'{{ source_name }}', '{{ table_name }}'{% raw %})}}{% endraw %}
+    select * from {% raw %}{{ source({% endraw %}'{{ source_name }}', '{{ table_name }}'{% raw %}) }}{% endraw %}
 
 ),
 


### PR DESCRIPTION
The testing strategy is basically, "will this macro compile without causing an error?"

And the answer at the moment is "no".

One of the macros takes a source as the argument, and I'm not sure what the best approach is to create a table in the warehouse, and then define that table as a source. I tried to `seed` it, but then it turns out that dbt compiles on `seed` and recognizes that the table doesn't yet exist. _Interesting._

Bad ideas I've had so far:
* Rename the `models` directory to `models_no_compile` and then add an integration test step _after_ the `seed` step that renames the directory to `models` 
* That's it
