### PR TITLE
Integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,92 @@
+
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.6.2-stretch
+      - image: circleci/postgres:9.6.5-alpine-ram
+
+    steps:
+      - checkout
+
+      - run:
+          run: setup_creds
+          command: |
+            echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > ${HOME}/gcloud-service-key.json
+
+      - restore_cache:
+          key: deps1-{{ .Branch }}
+
+      - run:
+          name: "Setup dbt"
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+
+            pip install --upgrade pip setuptools
+            pip install dbt --upgrade
+
+            mkdir -p ~/.dbt
+            cp integration_tests/ci/sample.profiles.yml ~/.dbt/profiles.yml
+
+      - run:
+          name: "Run Tests - Postgres"
+          environment:
+            CI_DBT_USER: root
+            CI_DBT_PASS: ''
+            CI_DBT_PORT: 5432
+            CI_DBT_DBNAME: circle_test
+          command: |
+            . venv/bin/activate
+            cd integration_tests
+            dbt deps --target postgres
+            dbt run-operation create_source_table --target postgres
+            dbt seed --target postgres --full-refresh
+            dbt run --target postgres
+            dbt test --target postgres
+
+      - run:
+          name: "Run Tests - Redshift"
+          command: |
+            . venv/bin/activate
+            echo `pwd`
+            cd integration_tests
+            dbt deps --target redshift
+            dbt run-operation create_source_table --target redshift
+            dbt seed --target redshift --full-refresh
+            dbt run --target redshift
+            dbt test --target redshift
+
+      - run:
+          name: "Run Tests - Snowflake"
+          command: |
+            . venv/bin/activate
+            echo `pwd`
+            cd integration_tests
+            dbt deps --target snowflake
+            dbt run-operation create_source_table --target snowflake
+            dbt seed --target snowflake --full-refresh
+            dbt run --target snowflake
+            dbt test --target snowflake
+
+      - run:
+          name: "Run Tests - BigQuery"
+          environment:
+              GCLOUD_SERVICE_KEY_PATH: "/home/circleci/gcloud-service-key.json"
+
+          command: |
+            . venv/bin/activate
+            echo `pwd`
+            cd integration_tests
+            dbt deps --target bigquery
+            dbt run-operation create_source_table --target bigquery
+            dbt seed --target bigquery --full-refresh
+            dbt run --target bigquery
+            dbt test --target bigquery
+
+
+      - save_cache:
+          key: deps1-{{ .Branch }}
+          paths:
+            - "venv"

--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -1,0 +1,49 @@
+
+# HEY! This file is used in the dbt-utils integrations tests with CircleCI.
+# You should __NEVER__ check credentials into version control. Thanks for reading :)
+
+config:
+    send_anonymous_usage_stats: False
+    use_colors: True
+
+codegen_integration_tests:
+  target: postgres
+  outputs:
+    postgres:
+      type: postgres
+      host: localhost
+      user: "{{ env_var('CI_DBT_USER') }}"
+      pass: "{{ env_var('CI_DBT_PASS') }}"
+      port: "{{ env_var('CI_DBT_PORT') }}"
+      dbname: "{{ env_var('CI_DBT_DBNAME') }}"
+      schema: codegen_integration_tests
+      threads: 1
+
+    redshift:
+      type: redshift
+      host: "{{ env_var('CI_REDSHIFT_DBT_HOST') }}"
+      user: "{{ env_var('CI_REDSHIFT_DBT_USER') }}"
+      pass: "{{ env_var('CI_REDSHIFT_DBT_PASS') }}"
+      dbname: "{{ env_var('CI_REDSHIFT_DBT_DBNAME') }}"
+      port: 5439
+      schema: codegen_integration_tests
+      threads: 1
+
+    bigquery:
+      type: bigquery
+      method: service-account
+      keyfile: "{{ env_var('GCLOUD_SERVICE_KEY_PATH') }}"
+      project: 'dbt-integration-tests'
+      schema: codegen_integration_tests
+      threads: 1
+
+    snowflake:
+      type: snowflake
+      account: "{{ env_var('CI_SNOWFLAKE_DBT_ACCOUNT') }}"
+      user: "{{ env_var('CI_SNOWFLAKE_DBT_USER') }}"
+      password: "{{ env_var('CI_SNOWFLAKE_DBT_PASS') }}"
+      role: "{{ env_var('CI_SNOWFLAKE_DBT_ROLE') }}"
+      database: "{{ env_var('CI_SNOWFLAKE_DBT_DATABASE') }}"
+      warehouse: "{{ env_var('CI_SNOWFLAKE_DBT_WAREHOUSE') }}"
+      schema: codegen_integration_tests
+      threads: 1

--- a/integration_tests/data/data__a_relation.csv
+++ b/integration_tests/data/data__a_relation.csv
@@ -1,0 +1,3 @@
+col_a,col_b
+1,a
+2,b

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,0 +1,19 @@
+
+name: 'codegen_integration_tests'
+version: '1.0'
+
+profile: 'codegen_integration_tests'
+
+source-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+data-paths: ["data"]
+macro-paths: ["macros"]
+
+target-path: "target"
+clean-targets:
+    - "target"
+    - "dbt_modules"
+
+seeds:
+  schema: raw_data

--- a/integration_tests/macros/assert_equal.sql
+++ b/integration_tests/macros/assert_equal.sql
@@ -1,0 +1,32 @@
+{% macro assert_equal(actual_object, expected_object) %}
+{% if not execute %}
+
+    {# pass #}
+
+{% elif actual_object != expected_object %}
+
+    {% set msg %}
+    Expected did not match actual
+
+    -----------
+    Actual:
+    -----------
+    --->{{ actual_object }}<---
+
+    -----------
+    Expected:
+    -----------
+    --->{{ expected_object }}<---
+
+    {% endset %}
+
+    {{ log(msg, info=True) }}
+
+    select 'fail'
+
+{% else %}
+
+    select 'ok' limit 0
+
+{% endif %}
+{% endmacro %}

--- a/integration_tests/macros/operations/create_source_table.sql
+++ b/integration_tests/macros/operations/create_source_table.sql
@@ -1,0 +1,24 @@
+{% macro create_source_table() %}
+
+{% set target_schema="codegen_integration_tests__data_source_schema" %}
+
+{% do adapter.create_schema(target.database, target_schema) %}
+
+{% set drop_table_sql %}
+drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_table
+{% endset %}
+
+{{ run_query(drop_table_sql) }}
+
+
+{% set create_table_sql %}
+create table {{ target_schema }}.codegen_integration_tests__data_source_table as (
+    select
+        1 as my_integer_col,
+        true as my_bool_col
+)
+{% endset %}
+
+{{ run_query(create_table_sql) }}
+
+{% endmacro %}

--- a/integration_tests/models/source.yml
+++ b/integration_tests/models/source.yml
@@ -1,0 +1,6 @@
+version: 2
+
+sources:
+  - name: codegen_integration_tests__data_source_schema
+    tables:
+      - name: codegen_integration_tests__data_source_table

--- a/integration_tests/packages.yml
+++ b/integration_tests/packages.yml
@@ -1,0 +1,3 @@
+
+packages:
+    - local: ../

--- a/integration_tests/tests/test_generate_base_models.sql
+++ b/integration_tests/tests/test_generate_base_models.sql
@@ -1,0 +1,28 @@
+
+{% set actual_base_model = codegen.generate_base_model(
+    source_name='codegen_integration_tests__data_source_schema',
+    table_name='codegen_integration_tests__data_source_table'
+  )
+%}
+
+{% set expected_base_model %}
+with source as (
+
+    select * from {%raw%}{{ source('codegen_integration_tests__data_source_schema', 'codegen_integration_tests__data_source_table') }}{%endraw%}
+
+),
+
+renamed as (
+
+    select
+        my_integer_col,
+        my_bool_col
+
+    from source
+
+)
+
+select * from renamed
+{% endset %}
+
+{{ assert_equal (actual_base_model | trim, expected_base_model | trim) }}

--- a/integration_tests/tests/test_generate_source.sql
+++ b/integration_tests/tests/test_generate_source.sql
@@ -1,0 +1,17 @@
+
+{% set raw_schema = generate_schema_name('raw_data') %}
+
+-- test default args
+{% set actual_source_yaml = codegen.generate_source(raw_schema) %}
+
+{% set expected_source_yaml %}
+version: 2
+
+sources:
+  - name: {{ raw_schema | trim }}
+    tables:
+      - name: data__a_relation
+{% endset %}
+
+
+{{ assert_equal (actual_source_yaml | trim, expected_source_yaml | trim) }}

--- a/integration_tests/tests/test_generate_source_all_args.sql
+++ b/integration_tests/tests/test_generate_source_all_args.sql
@@ -1,0 +1,24 @@
+{% set raw_schema = generate_schema_name('raw_data') %}
+
+-- test all args
+{% set actual_source_yaml = codegen.generate_source(
+    schema_name=raw_schema,
+    database_name=target.database,
+    generate_columns=True
+) %}
+
+
+{% set expected_source_yaml %}
+version: 2
+
+sources:
+  - name: {{ raw_schema | trim }}
+    tables:
+      - name: data__a_relation
+        columns:
+          - name: col_a
+          - name: col_b
+
+{% endset %}
+
+{{ assert_equal (actual_source_yaml | trim, expected_source_yaml | trim) }}

--- a/macros/generate_base_model.sql
+++ b/macros/generate_base_model.sql
@@ -7,7 +7,7 @@
 {% set base_model_sql %}
 with source as (
 
-    select * from {% raw %}{{ source({% endraw %}'{{ source_name }}', '{{ table_name }}'{% raw %})}}{% endraw %}
+    select * from {% raw %}{{ source({% endraw %}'{{ source_name }}', '{{ table_name }}'{% raw %}) }}{% endraw %}
 
 ),
 
@@ -15,7 +15,7 @@ renamed as (
 
     select
         {%- for column in column_names %}
-        {{ column }}{{"," if not loop.last}}
+        {{ column | lower }}{{"," if not loop.last}}
         {%- endfor %}
 
     from source
@@ -28,6 +28,7 @@ select * from renamed
 {% if execute %}
 
 {{ log(base_model_sql, info=True) }}
+{% do return(base_model_sql) %}
 
 {% endif %}
 {% endmacro %}

--- a/macros/generate_source.sql
+++ b/macros/generate_source.sql
@@ -1,34 +1,39 @@
 {% macro get_tables_in_schema(schema_name) %}
+
     {% set tables=dbt_utils.get_tables_by_prefix(
             schema=schema_name,
             prefix=''
         )
     %}
 
-    {% set table_list=[] %}
+    {% set table_list= tables | map(attribute = 'identifier') %}
 
-    {% for table in tables %}
-        {% do table_list.append(table.identifier) %}
-    {% endfor %}
     {{ return(table_list | sort) }}
+    {{ log("*** table list ***", info=True) }}
+    {{ log(table_list, info=True) }}
+
 {% endmacro %}
 
 
 ---
 {% macro generate_source(schema_name, database_name=target.database, generate_columns=False) %}
 
+{% if target.type == 'snowflake' %}
+  {% set schema_name = schema_name | upper %}
+{% endif %}
+
 {% set sources_yaml=[] %}
 
 {% do sources_yaml.append('version: 2') %}
 {% do sources_yaml.append('') %}
 {% do sources_yaml.append('sources:') %}
-{% do sources_yaml.append('  - name: ' ~ schema_name) %}
+{% do sources_yaml.append('  - name: ' ~ schema_name | lower) %}
 {% do sources_yaml.append('    tables:') %}
 
 {% set tables=codegen.get_tables_in_schema(schema_name) %}
 
 {% for table in tables %}
-    {% do sources_yaml.append('      - name: ' ~ table) %}
+    {% do sources_yaml.append('      - name: ' ~ table | lower ) %}
 
     {% if generate_columns %}
     {% do sources_yaml.append('        columns:') %}
@@ -42,7 +47,7 @@
         {% set columns=adapter.get_columns_in_relation(table_relation) %}
 
         {% for column in columns %}
-            {% do sources_yaml.append('          - name: ' ~ column.name) %}
+            {% do sources_yaml.append('          - name: ' ~ column.name | lower ) %}
         {% endfor %}
             {% do sources_yaml.append('') %}
 
@@ -52,7 +57,9 @@
 
 {% if execute %}
 
-    {{ log(sources_yaml | join ('\n'), info=True) }}
+    {% set joined = sources_yaml | join ('\n') %}
+    {{ log(joined, info=True) }}
+    {% do return(joined) %}
 
 {% endif %}
 


### PR DESCRIPTION
General approach:
1. Created a macro, `assert_equal` that is a custom data test that two Jinja objects are equal, returning 1 record when they aren't (fail) (rather than throwing a compilation error, as I want the rest of the tests to run), and 0 records when they are the same (pass)
2. Used this macro in three separate custom data tests to test the actual output of each macro against expected


Weirdness that I had to handle:
The `generate_base_model` needs to be passed a valid `source`. As such, a table _has_ to already exist in the warehouse.
I first tried to do this as a `seed`, but dbt compiles when you try to run `dbt seed`, so it was failing because the table did not yet exist. Instead, I had to do it as a `run-operation` and write the DDL (😱) manually, then pointing to that schema in my `sources.yml` file.

Also, casing on Snowflake (see [related PR on utils](https://github.com/fishtown-analytics/dbt-utils/pull/148)).