### PR TITLE
Add generate model yaml macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,6 @@ select * from renamed
 ```
 4. Paste the output in to a model, and refactor as required.
 
-
-
-
 ## generate_model_yaml ([source](macros/generate_model_yaml.sql))
 This macro generates the YAML for a model, which you can then paste into a
 schema.yml file.

--- a/README.md
+++ b/README.md
@@ -101,3 +101,42 @@ renamed as (
 select * from renamed
 ```
 4. Paste the output in to a model, and refactor as required.
+
+
+
+
+## generate_model_yaml ([source](macros/generate_model_yaml.sql))
+This macro generates the YAML for a model, which you can then paste into a
+schema.yml file.
+
+### Arguments:
+* `model_name` (required): The model you wish to generate YAML for.
+
+### Usage:
+1. Create a model.
+2. Use the macro (in dbt Develop, or in a scratch file), and compile your code
+```
+{{
+  codegen.generate_model_yaml(
+    model_name='customers'
+  )
+}}
+```
+Alternatively, call the macro as an [operation](https://docs.getdbt.com/docs/using-operations):
+```
+$ dbt run-operation generate_model_yaml --args '{"model_name": "customers"}'
+```
+
+3. The YAML for a base model will be logged to the command line
+```txt
+version: 2
+
+models:
+  - name: customers
+    columns:
+      - name: customer_id
+        description: ""
+      - name: customer_name
+        description: ""
+```
+4. Paste the output in to a schema.yml file, and refactor as required.

--- a/integration_tests/tests/test_generate_model_yaml.sql
+++ b/integration_tests/tests/test_generate_model_yaml.sql
@@ -10,7 +10,7 @@ models:
   - name: model_yaml
     tables:
       - name: codegen_integration_tests__data_source_table
-        descriptions: ""
+        description: ""
         columns:
           - name: col_a
             description: ""

--- a/integration_tests/tests/test_generate_model_yaml.sql
+++ b/integration_tests/tests/test_generate_model_yaml.sql
@@ -1,0 +1,23 @@
+
+{% set actual_model_yaml = codegen.generate_model_yaml(
+    model_name='codegen_integration_tests__data_source_table'
+  )
+%}
+
+{% set expected_model_yaml %}
+version: 2
+
+models:
+  - name: model_yaml
+    tables:
+      - name: codegen_integration_tests__data_source_table
+        descriptions: ""
+        columns:
+          - name: col_a
+            description: ""
+          - name: col_b
+            description: ""
+
+{% endset %}
+
+{{ assert_equal (actual_model_yaml | trim, expected_model_yaml | trim) }}

--- a/integration_tests/tests/test_generate_model_yaml.sql
+++ b/integration_tests/tests/test_generate_model_yaml.sql
@@ -1,4 +1,3 @@
-
 {% set actual_model_yaml = codegen.generate_model_yaml(
     model_name='codegen_integration_tests__data_source_table'
   )

--- a/macros/generate_model_yaml.sql
+++ b/macros/generate_model_yaml.sql
@@ -14,7 +14,7 @@
 
 {% for column in columns %}
     {% do model_yaml.append('      - name: ' ~ column.name | lower ) %}
-    {% do model_yaml.append('      - description: ""') %}
+    {% do model_yaml.append('        description: ""') %}
     {% do model_yaml.append('') %}
 {% endfor %}
 

--- a/macros/generate_model_yaml.sql
+++ b/macros/generate_model_yaml.sql
@@ -7,7 +7,7 @@
 {% do model_yaml.append('models:') %}
 {% do model_yaml.append('  - name: ' ~ model_name | lower) %}
 {% do model_yaml.append('    description: ""') %}
-{% do model_yaml.append('    columns: ""') %}
+{% do model_yaml.append('    columns:') %}
 
 {% set relation=ref(model_name) %}
 {%- set columns = adapter.get_columns_in_relation(relation) -%}

--- a/macros/generate_model_yaml.sql
+++ b/macros/generate_model_yaml.sql
@@ -1,0 +1,29 @@
+{% macro generate_model_yaml(model_name) %}
+
+{% set model_yaml=[] %}
+
+{% do model_yaml.append('version: 2') %}
+{% do model_yaml.append('') %}
+{% do model_yaml.append('models:') %}
+{% do model_yaml.append('  - name: ' ~ model_name | lower) %}
+{% do model_yaml.append('    description: ""') %}
+{% do model_yaml.append('    columns: ""') %}
+
+{% set relation=ref(model_name) %}
+{%- set columns = adapter.get_columns_in_relation(relation) -%}
+
+{% for column in columns %}
+    {% do model_yaml.append('      - name: ' ~ column.name | lower ) %}
+    {% do model_yaml.append('      - description: ""') %}
+    {% do model_yaml.append('') %}
+{% endfor %}
+
+{% if execute %}
+
+    {% set joined = model_yaml | join ('\n') %}
+    {{ log(joined, info=True) }}
+    {% do return(joined) %}
+
+{% endif %}
+
+{% endmacro %}


### PR DESCRIPTION
I add a macro which takes in a model name and returns yml. Right now, I added default empty-string descriptions to model and columns, but I can take that out. 