### PR TITLE
New env vars for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run:
           run: setup_creds
           command: |
-            echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > ${HOME}/gcloud-service-key.json
+            echo $BIGQUERY_SERVICE_ACCOUNT_JSON > ${HOME}/bigquery-service-key.json
 
       - restore_cache:
           key: deps1-{{ .Branch }}
@@ -33,10 +33,11 @@ jobs:
       - run:
           name: "Run Tests - Postgres"
           environment:
-            CI_DBT_USER: root
-            CI_DBT_PASS: ''
-            CI_DBT_PORT: 5432
-            CI_DBT_DBNAME: circle_test
+            POSTGRES_TEST_HOST: localhost
+            POSTGRES_TEST_USER: root
+            POSTGRES_TEST_PASS: ''
+            POSTGRES_TEST_PORT: 5432
+            POSTGRES_TEST_DBNAME: circle_test
           command: |
             . venv/bin/activate
             cd integration_tests
@@ -73,7 +74,7 @@ jobs:
       - run:
           name: "Run Tests - BigQuery"
           environment:
-              GCLOUD_SERVICE_KEY_PATH: "/home/circleci/gcloud-service-key.json"
+              BIGQUERY_SERVICE_KEY_PATH: "/home/circleci/bigquery-service-key.json"
 
           command: |
             . venv/bin/activate

--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -1,49 +1,49 @@
 
-# HEY! This file is used in the dbt-utils integrations tests with CircleCI.
+# HEY! This file is used in the dbt-codegen integrations tests with CircleCI.
 # You should __NEVER__ check credentials into version control. Thanks for reading :)
 
 config:
     send_anonymous_usage_stats: False
     use_colors: True
 
-codegen_integration_tests:
+integration_tests:
   target: postgres
   outputs:
     postgres:
       type: postgres
-      host: localhost
-      user: "{{ env_var('CI_DBT_USER') }}"
-      pass: "{{ env_var('CI_DBT_PASS') }}"
-      port: "{{ env_var('CI_DBT_PORT') }}"
-      dbname: "{{ env_var('CI_DBT_DBNAME') }}"
-      schema: codegen_integration_tests
+      host: "{{ env_var('POSTGRES_TEST_HOST') }}"
+      user: "{{ env_var('POSTGRES_TEST_USER') }}"
+      pass: "{{ env_var('POSTGRES_TEST_PASS') }}"
+      port: "{{ env_var('POSTGRES_TEST_PORT') }}"
+      dbname: "{{ env_var('POSTGRES_TEST_DBNAME') }}"
+      schema: dbt_utils_integration_tests_postgres
       threads: 1
 
     redshift:
       type: redshift
-      host: "{{ env_var('CI_REDSHIFT_DBT_HOST') }}"
-      user: "{{ env_var('CI_REDSHIFT_DBT_USER') }}"
-      pass: "{{ env_var('CI_REDSHIFT_DBT_PASS') }}"
-      dbname: "{{ env_var('CI_REDSHIFT_DBT_DBNAME') }}"
-      port: 5439
-      schema: codegen_integration_tests
+      host: "{{ env_var('REDSHIFT_TEST_HOST') }}"
+      user: "{{ env_var('REDSHIFT_TEST_USER') }}"
+      pass: "{{ env_var('REDSHIFT_TEST_PASS') }}"
+      dbname: "{{ env_var('REDSHIFT_TEST_DBNAME') }}"
+      port: "{{ env_var('REDSHIFT_TEST_PORT') }}"
+      schema: dbt_utils_integration_tests_redshift
       threads: 1
 
     bigquery:
       type: bigquery
       method: service-account
-      keyfile: "{{ env_var('GCLOUD_SERVICE_KEY_PATH') }}"
-      project: 'dbt-integration-tests'
-      schema: codegen_integration_tests
+      keyfile: "{{ env_var('BIGQUERY_SERVICE_KEY_PATH') }}"
+      project: "{{ env_var('BIGQUERY_TEST_DATABASE') }}"
+      schema: dbt_utils_integration_tests_bigquery
       threads: 1
-
+      
     snowflake:
       type: snowflake
-      account: "{{ env_var('CI_SNOWFLAKE_DBT_ACCOUNT') }}"
-      user: "{{ env_var('CI_SNOWFLAKE_DBT_USER') }}"
-      password: "{{ env_var('CI_SNOWFLAKE_DBT_PASS') }}"
-      role: "{{ env_var('CI_SNOWFLAKE_DBT_ROLE') }}"
-      database: "{{ env_var('CI_SNOWFLAKE_DBT_DATABASE') }}"
-      warehouse: "{{ env_var('CI_SNOWFLAKE_DBT_WAREHOUSE') }}"
-      schema: codegen_integration_tests
+      account: "{{ env_var('SNOWFLAKE_TEST_ACCOUNT') }}"
+      user: "{{ env_var('SNOWFLAKE_TEST_USER') }}"
+      password: "{{ env_var('SNOWFLAKE_TEST_PASSWORD') }}"
+      role: "{{ env_var('SNOWFLAKE_TEST_ROLE') }}"
+      database: "{{ env_var('SNOWFLAKE_TEST_DATABASE') }}"
+      warehouse: "{{ env_var('SNOWFLAKE_TEST_WAREHOUSE') }}"
+      schema: dbt_utils_integration_tests_snowflake
       threads: 1

--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -16,7 +16,7 @@ integration_tests:
       pass: "{{ env_var('POSTGRES_TEST_PASS') }}"
       port: "{{ env_var('POSTGRES_TEST_PORT') }}"
       dbname: "{{ env_var('POSTGRES_TEST_DBNAME') }}"
-      schema: dbt_utils_integration_tests_postgres
+      schema: codegen_integration_tests_postgres
       threads: 1
 
     redshift:
@@ -26,7 +26,7 @@ integration_tests:
       pass: "{{ env_var('REDSHIFT_TEST_PASS') }}"
       dbname: "{{ env_var('REDSHIFT_TEST_DBNAME') }}"
       port: "{{ env_var('REDSHIFT_TEST_PORT') }}"
-      schema: dbt_utils_integration_tests_redshift
+      schema: codegen_integration_tests_redshift
       threads: 1
 
     bigquery:
@@ -34,7 +34,7 @@ integration_tests:
       method: service-account
       keyfile: "{{ env_var('BIGQUERY_SERVICE_KEY_PATH') }}"
       project: "{{ env_var('BIGQUERY_TEST_DATABASE') }}"
-      schema: dbt_utils_integration_tests_bigquery
+      schema: codegen_integration_tests_bigquery
       threads: 1
       
     snowflake:
@@ -45,5 +45,5 @@ integration_tests:
       role: "{{ env_var('SNOWFLAKE_TEST_ROLE') }}"
       database: "{{ env_var('SNOWFLAKE_TEST_DATABASE') }}"
       warehouse: "{{ env_var('SNOWFLAKE_TEST_WAREHOUSE') }}"
-      schema: dbt_utils_integration_tests_snowflake
+      schema: codegen_integration_tests_snowflake
       threads: 1

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -2,7 +2,7 @@ name: 'codegen_integration_tests'
 version: '1.0'
 config-version: 2
 
-profile: 'codegen_integration_tests'
+profile: 'integration_tests'
 
 source-paths: ["models"]
 analysis-paths: ["analysis"]


### PR DESCRIPTION
* Connect to sandboxed, cost-controlled instances of Redshift, Snowflake, BigQuery
* Use same env var nomenclature that dbt uses for its integration tests