### PR TITLE
Add optional leading_commas arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Fixes
 
 ## Features
-- Add optional leading_commas arg to generate_base_model
+- Add optional leading_commas arg to generate_base_model (#41 @jaypeedevlin)
 
 ## Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 ## Features
+- Add optional leading_commas arg to generate_base_model
 
 ## Other
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ model.
 ### Arguments:
 * `source_name` (required): The source you wish to generate base model SQL for.
 * `table_name` (required): The source table you wish to generate base model SQL for.
+* `leading_commas` (optional, default=False): Whether you want your commas to be leading (vs trailing).
 
 
 ### Usage:

--- a/integration_tests/tests/test_generate_base_models_leading.sql
+++ b/integration_tests/tests/test_generate_base_models_leading.sql
@@ -1,0 +1,29 @@
+
+{% set actual_base_model = codegen.generate_base_model(
+    source_name='codegen_integration_tests__data_source_schema',
+    table_name='codegen_integration_tests__data_source_table',
+    leading_commas=True,
+  )
+%}
+
+{% set expected_base_model %}
+with source as (
+
+    select * from {%raw%}{{ source('codegen_integration_tests__data_source_schema', 'codegen_integration_tests__data_source_table') }}{%endraw%}
+
+),
+
+renamed as (
+
+    select
+        my_integer_col
+        , my_bool_col
+
+    from source
+
+)
+
+select * from renamed
+{% endset %}
+
+{{ assert_equal (actual_base_model | trim, expected_base_model | trim) }}

--- a/macros/generate_base_model.sql
+++ b/macros/generate_base_model.sql
@@ -1,4 +1,4 @@
-{% macro generate_base_model(source_name, table_name) %}
+{% macro generate_base_model(source_name, table_name, leading_commas=False) %}
 
 {%- set source_relation = source(source_name, table_name) -%}
 
@@ -14,9 +14,15 @@ with source as (
 renamed as (
 
     select
+        {%- if leading_commas -%}
+        {%- for column in column_names %}
+        {{", " if not loop.first}}{{ column | lower }}
+        {%- endfor %}
+        {%- else -%}
         {%- for column in column_names %}
         {{ column | lower }}{{"," if not loop.last}}
-        {%- endfor %}
+        {%- endfor -%}
+        {%- endif %}
 
     from source
 


### PR DESCRIPTION
## Description & motivation
Closes #30 

This adds leading comma support by adding a `leading_commas` arg to the `generate_base_model` macro. If the arg is omitted, the macro behaves the same.  If `True`, the output uses leading rather than trailing commas.

## Checklist
- [X] I have verified that these changes work locally
- [X] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my models (and macros if applicable)
